### PR TITLE
installation instructions updated to mention that the conda-forge ver…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 
 Tierpsy Tracker is a multi-animal tracker developed in the [MRC-LMS](http://lms.mrc.ac.uk/) [Behavioural Genomics Group](http://behave.csc.mrc.ac.uk/) at Imperial College London. The project combines the throughput of multiworm tracking with the resolution of single worm tracking, which means you can extract detailed phenotypic fingerprints from more animals.  A large field of view also makes it possible to analyse collective behaviours that depend on animal interactions.  The code is open source and extensible and we have ongoing projects using the tracker to analyse fish, *Drosophila* larvae, and fluorescently labelled worms.
 
-The easiest way to install Tierpsy Tracker is to use the conda-forge as:
-```
-conda install tierpsy -c conda-forge
-```
 For more details see the [installation](docs/INSTALLATION.md) instructions section.
 
 ## [Installation Instructions](docs/INSTALLATION.md)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation Instructions
 
-## Installation from precompiled packages [recommended]
+## Installation from precompiled packages [latest version not available]
 - Download python 3.6>= using [anaconda](https://www.anaconda.com/download/) or [miniconda](https://conda.io/miniconda.html) if you prefer a lighter installation.
 - Open a Terminal in OSX or Linux. In Windows you need to open the Anaconda Prompt.
 - [Optional] I would recommend to create and activate an [enviroment](https://conda.io/docs/user-guide/tasks/manage-environments.html) as:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 keras=2.1.5 
-opencv=3.4.3
-tensorflow=1.0.0
+opencv=3.4.2
+tensorflow
 numpy >=1.14
 matplotlib 
 pytables 


### PR DESCRIPTION
Minor changes regarding installation of tierpsy:
1) The conda-forge version of tierpsy is not up-to-date. I added a note mentioning this in the installation instructions.
2) I updated the requirements.txt, so that the installation from source works, if one follows the instructions.