### PR TITLE
Bugfixes: summary and cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Tierpsy Tracker is a multi-animal tracker developed in the [MRC-LMS](http://lms.
 
 For more details see the [installation](docs/INSTALLATION.md) instructions section.
 
-## [Installation Instructions](docs/INSTALLATION.md)
-## [How to Use](docs/HOWTO.md)
-## [Algorithm Explanation](docs/EXPLANATION.md)
-## [Output Files](docs/OUTPUTS.md)
+### Publications
+* Javer, A., Currie, M., Lee, C.W. et al. An open-source platform for analyzing and sharing worm-behavior data. _Nat Methods_ **15**, 645–646 (2018). https://doi.org/10.1038/s41592-018-0112-1
+
+* Javer, A., Ripoll-Sánchez, L., and Brown, A.E.X. Powerful and interpretable behavioural features for quantitative phenotyping of _Caenorhabditis elegans_. _Phil. Trans. R. Soc. B_ **373**: 20170375 (2018).
+http://doi.org/10.1098/rstb.2017.0375
+
+### [Installation Instructions](docs/INSTALLATION.md)
+### [How to Use](docs/HOWTO.md)
+### [Algorithm Explanation](docs/EXPLANATION.md)
+### [Output Files](docs/OUTPUTS.md)

--- a/tierpsy/summary/process_tierpsy.py
+++ b/tierpsy/summary/process_tierpsy.py
@@ -232,9 +232,10 @@ def tierpsy_trajectories_summary(
             # concatenate all trajectories in given time window into one dataframe
             all_summary = pd.concat(all_summary, ignore_index=True, sort=False)
             # attach whether the wells was good or bad
-            all_summary = all_summary.merge(good_wells_df,
-                                            on='well_name',
-                                            how='left')
+            if is_fov_tosplit:  #  but only do this if we have wells
+                all_summary = all_summary.merge(good_wells_df,
+                                                on='well_name',
+                                                how='left')
 
         # add dataframe to the list of summaries for all time windows
         all_summaries_list.append(all_summary)

--- a/tierpsy_windows.yml
+++ b/tierpsy_windows.yml
@@ -16,7 +16,7 @@ dependencies:
   - cloudpickle=1.4.1
   - cryptography=2.9.2
   - cycler=0.10.0
-  - cython=0.29.18
+  - cython=0.29.19
   - cytoolz=0.10.1
   - dask-core=2.16.0
   - decorator=4.4.2

--- a/tierpsy_windows_conda4_5_11.yml
+++ b/tierpsy_windows_conda4_5_11.yml
@@ -16,7 +16,7 @@ dependencies:
   - cloudpickle=1.4.1
   - cryptography=2.9.2
   - cycler=0.10.0
-  - cython=0.29.18
+  - cython=0.29.19
   - cytoolz=0.10.1
   - dask-core=2.16.0
   - decorator=4.4.2


### PR DESCRIPTION
Windows installation `*.yml` files:
A bug in `cython==0.29.18` prevented succesfully carrying out the `pip install` step of the installation on Windows machines. Switching to `cython==0.29.19` to fix this.

`tierpsy/summary/process_tierpsy`:
In `tierpsy_trajectories_summary` the variable `good_wells_df` was being referenced even if the FOV was not split.

'README.md':
Added tierpsy papers.

