### PR TITLE
docs: added troubleshooting for [WinError 126] in Windows installation without CUDA

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -80,6 +80,7 @@ tierpsy_gui
 - Make sure you have an up-to-date version of conda. To update conda, `conda update -n base -c defaults conda`. We tested on `conda 4.8.2`.
 - Try the alternative command `conda env create -f tierpsy_windows_conda4_5_11.yml`
 - `pip install -e .` has been known to fail with an error stating that `command 'cl.exe' failed: No such file or directory`. See the [Known Issues](ISSUES.md) for a solution.
+- Windows machines without a CUDA enabled GPU: see the [Known Issues](ISSUES.md).
 
 ### Linux
 - Open a shell and type:

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -26,3 +26,14 @@
     - close this x86_x64 Cross Tools Prompt
   - In the Anaconda prompt:
     - `tierpsy_gui`
+
+
+- On Windows machines **without a CUDA capable GPU**, Tierpsy throws the following error during the analysis:
+  ```
+  OSError: [WinError 126] The specified module could not be found
+  ```
+  The steps below have fixed the issue for us:
+  - In the Anaconda Prompt
+    - Activate the conda environment with `conda activate tierpsy`
+    - Install the CPU-only version of pytorch: `conda install pytorch torchvision cpuonly -c pytorch`
+    - `tierpsy_gui`


### PR DESCRIPTION
### Issue:
Two users had a `OSError: [WinError 126] The specified module could not be found` when starting the batch processing, after an apparently successful installation. 
In both cases, Tierpsy was installed on a Windows machine without a CUDA-enabled GPU

### Fix:
Install the CPU-only version of pytorch: `conda install pytorch torchvision cpuonly -c pytorch`