### PR TITLE
bugfix for normalisation of area by worm length

### DIFF
--- a/tierpsy/features/tierpsy_features/summary_stats.py
+++ b/tierpsy/features/tierpsy_features/summary_stats.py
@@ -68,7 +68,7 @@ def _normalize_by_w_length(timeseries_data, feats2norm):
         elif units_t == '1/L':
             conversion_vec = median_length_vec
         elif units_t == 'L^2':
-            conversion_vec = median_length_vec**2
+            conversion_vec = 1/median_length_vec**2
         return conversion_vec
 
     timeseries_data = timeseries_data.copy()


### PR DESCRIPTION
At the summary_stats step, some features get normalised by worm length.
This is achieved by multiplying the features by a conversion_vec.
Features with units of length were correctly multiplied by `1/median_length`, where `median_length` is the median length of the worm. 
Features with units of inverse length were correctly multiplied by `median_length`. 
Features with units of length squared were multiplied by `median_length**2` instead of by `1/median_length**2`.
The only feature affected is the area.