### PR TITLE
Improvements to wells masking, new pytorch model

### DIFF
--- a/tierpsy/analysis/feat_tierpsy/get_tierpsy_features.py
+++ b/tierpsy/analysis/feat_tierpsy/get_tierpsy_features.py
@@ -16,6 +16,7 @@ from tierpsy.helper.misc import TimeCounter, print_flush, get_base_name, TABLE_F
 from tierpsy.helper.params import read_fps, read_ventral_side
 
 from tierpsy.analysis.split_fov.FOVMultiWellsSplitter import FOVMultiWellsSplitter
+from tierpsy.analysis.split_fov.helper import was_fov_split
 
 def save_timeseries_feats_table(features_file, derivate_delta_time, fovsplitter_param={}):
     timeseries_features = []
@@ -161,7 +162,7 @@ def save_feats_stats(features_file, derivate_delta_time):
         fps = fid.get_storer('/trajectories_data').attrs['fps']
         timeseries_data = fid['/timeseries_data']
         blob_features = fid['/blob_features'] if '/blob_features' in fid else None
-        is_fov_tosplit = ('/fov_wells' in fid) # do we need split-FOV sumaries?
+        is_fov_tosplit = was_fov_split(features_file) # do we need split-FOV sumaries?
 
     # check
     if is_fov_tosplit:

--- a/tierpsy/analysis/feat_tierpsy/get_tierpsy_features.py
+++ b/tierpsy/analysis/feat_tierpsy/get_tierpsy_features.py
@@ -161,21 +161,12 @@ def save_feats_stats(features_file, derivate_delta_time):
         fps = fid.get_storer('/trajectories_data').attrs['fps']
         timeseries_data = fid['/timeseries_data']
         blob_features = fid['/blob_features'] if '/blob_features' in fid else None
+        is_fov_tosplit = ('/fov_wells' in fid) # do we need split-FOV sumaries?
 
-    # do we need split-FOV sumaries?
-    if 'well_name' not in timeseries_data.columns:
-        # for some weird reason, save_feats_stats is being called on an old
-        # featuresN file without calling save_timeseries_feats_table first
-        is_fov_tosplit = False
-    else:
-        # timeseries_data has been updated and now has a well_name column
-        if len(set(timeseries_data['well_name']) - set(['n/a'])) > 0:
-            is_fov_tosplit = True
-            print('have to split by fov')
-        else:
-            assert all(timeseries_data['well_name']=='n/a'), \
-                'Something is wrong with well naming - go check save_feats_stats'
-            is_fov_tosplit = False
+    # check
+    if is_fov_tosplit:
+        assert 'well_name' in timeseries_data.columns, (
+            'fov_wells in features file but no well_name in timeseries_data')
 
     #Now I want to calculate the stats of the video
     if is_fov_tosplit:

--- a/tierpsy/analysis/split_fov/FOVMultiWellsSplitter.py
+++ b/tierpsy/analysis/split_fov/FOVMultiWellsSplitter.py
@@ -350,6 +350,14 @@ class FOVMultiWellsSplitter(object):
         for d in ['x','y']:
             self.wells[d+'_min'] = self.wells[d] - self.wells['r']
             self.wells[d+'_max'] = self.wells[d] + self.wells['r']
+        # bound wells to be in frame (to avoid pains later)
+        # np.maximum does entrywise max(a,b)
+        self.wells['x_min'] = np.maximum(self.wells['x_min'], 0)
+        self.wells['y_min'] = np.maximum(self.wells['y_min'], 0)
+        self.wells['x_max'] = np.minimum(
+            self.wells['x_max'], self.img_shape[1])
+        self.wells['y_max'] = np.minimum(
+            self.wells['y_max'], self.img_shape[0])
         # and for debugging
         self._gridminres = (result, meanimg, npixels)  # save output of diff evo
         # looked at ~10k FOV splits, 0.6 is a good threshold to at least flag

--- a/tierpsy/analysis/split_fov/FOVMultiWellsSplitter.py
+++ b/tierpsy/analysis/split_fov/FOVMultiWellsSplitter.py
@@ -949,6 +949,15 @@ class FOVMultiWellsSplitter(object):
             m = max(y-vert_edge,0)
             M = min(y+vert_edge, self.img_shape[0])
             mask[m:M,:] = 0
+        # mask everything outside the wells
+        M = self.wells['x_max'].max()
+        mask[:, M:] = 0
+        m = self.wells['x_min'].min()
+        mask[:, :m] = 0
+        M = self.wells['y_max'].max()
+        mask[M:, :] = 0
+        m = self.wells['y_min'].min()
+        mask[:m, :] = 0
 
         return mask
 

--- a/tierpsy/analysis/split_fov/helper.py
+++ b/tierpsy/analysis/split_fov/helper.py
@@ -58,7 +58,7 @@ CAM2CH_DICT = {"22956818":'Ch1', # Hydra01
                "22594548":'Ch6'}
 
 
-# this can't be a nice and simple dictionary because people may want to use 
+# this can't be a nice and simple dictionary because people may want to use
 # this info in the other direction
 
 CAM2CH_list = [('22956818', 'Ch1', 'Hydra01'), # Hydra01
@@ -92,7 +92,7 @@ CAM2CH_list = [('22956818', 'Ch1', 'Hydra01'), # Hydra01
                ('22594549', 'Ch5', 'Hydra05'),
                ('22594548', 'Ch6', 'Hydra05')]
 
-CAM2CH_df = pd.DataFrame(CAM2CH_list, 
+CAM2CH_df = pd.DataFrame(CAM2CH_list,
                          columns=['camera_serial', 'channel', 'rig'])
 
 
@@ -148,7 +148,7 @@ UPRIGHT_96WP = pd.DataFrame.from_dict({('Ch1',0):[ 'A1', 'B1', 'C1', 'D1'],
 def get_mwp_map(total_n_wells, whichsideup):
     """
     Given a total number of wells, and whether the multiwell plate
-    is upright or upside-down, returns a dataframe with the correct 
+    is upright or upside-down, returns a dataframe with the correct
     channel/row/column -> well_name mapping
     (this works on the Hydra imaging systems - by LoopBio Gmbh - used in Andre
     Brown's lab)
@@ -192,7 +192,7 @@ def parse_camera_serial(filename):
 
 def calculate_bgnd_from_masked_fulldata(masked_image_file):
     """
-    - Opens the masked_image_file hdf5 file, reads the /full_data node and 
+    - Opens the masked_image_file hdf5 file, reads the /full_data node and
       creates a "background" by taking the maximum value of each pixel over time.
     - Parses the file name to find a camera serial number
     - reads the pixel/um ratio from the masked_image_file
@@ -207,9 +207,9 @@ def calculate_bgnd_from_masked_fulldata(masked_image_file):
         assert is_light_background, \
         'MultiWell recognition is only available for brightfield at the moment'
         img = np.max(fid.get_node('/full_data'), axis=0)
-    
+
     camera_serial = parse_camera_serial(masked_image_file)
-    
+
     return img, camera_serial, microns_per_pixel
 
 
@@ -225,14 +225,14 @@ def make_square_template(n_pxls=150, rel_width=0.8, blurring=0.1, dtype_out='flo
     zz = (1 - np.tanh( (abs(xx)-rel_width/2)/blurring ))
     zz = zz * (1-np.tanh( (abs(yy)-rel_width/2)/blurring ))
     zz = zz/4
-    
+
     # add bright border
     edge = int(0.05 * n_pxls)
     zz[:edge,:] = 1
     zz[-edge:,:] = 1
     zz[:,:edge] = 1
     zz[:,-edge:] = 1
-    
+
     if dtype_out == 'uint8':
         zz *= 255
         zz = zz.astype(np.uint8)
@@ -240,29 +240,34 @@ def make_square_template(n_pxls=150, rel_width=0.8, blurring=0.1, dtype_out='flo
         pass
     else:
         raise ValueError("Only 'float' and 'uint8' are valid dtypes for this")
-        
-    
+
+
     return zz
 
 
-def was_fov_split(timeseries_data):
-    """
-    Check if the FOV was split, looking at timeseries_data
-    """
-    if 'well_name' not in timeseries_data.columns:
-        # for some weird reason, save_feats_stats is being called on an old 
-        # featuresN file without calling save_timeseries_feats_table first
-        is_fov_split = False
-    else:
-        # timeseries_data has been updated and now has a well_name column
-        if len(set(timeseries_data['well_name']) - set(['n/a'])) > 0:
-            is_fov_split = True
-#            print('have to split fov by well')
-        else:
-            assert all(timeseries_data['well_name']=='n/a'), \
-                'Something is wrong with well naming - go check save_feats_stats'
-            is_fov_split = False
-    return is_fov_split
+# def was_fov_split(timeseries_data):
+#     """
+#     Check if the FOV was split, looking at timeseries_data
+#     """
+#     if 'well_name' not in timeseries_data.columns:
+#         # for some weird reason, save_feats_stats is being called on an old
+#         # featuresN file without calling save_timeseries_feats_table first
+#         is_fov_split = False
+#     else:
+#         # timeseries_data has been updated and now has a well_name column
+#         if len(set(timeseries_data['well_name']) - set(['n/a'])) > 0:
+#             is_fov_split = True
+# #            print('have to split fov by well')
+#         else:
+#             assert all(timeseries_data['well_name']=='n/a'), \
+#                 'Something is wrong with well naming - go check save_feats_stats'
+#             is_fov_split = False
+#     return is_fov_split
+
+def was_fov_split(fname):
+    with pd.HDFStore(fname, 'r') as fid:
+        is_fov_tosplit = ('/fov_wells' in fid)
+    return is_fov_tosplit
 
 
 def naive_normalise(img):
@@ -280,22 +285,22 @@ def fft_convolve2d(x,y):
     return cc
 
 
-def simulate_wells_lattice(img_shape, x_off, y_off, sp, nwells=None, template_shape='square'): 
+def simulate_wells_lattice(img_shape, x_off, y_off, sp, nwells=None, template_shape='square'):
     """
     Create mock fov by placing well templates onto a square lattice
-    Very simply uses the input parameters and range to define where the wells 
-    will go, and then places the template in a padded canvas. 
+    Very simply uses the input parameters and range to define where the wells
+    will go, and then places the template in a padded canvas.
     The canvas is then cut to be of img_shape again.
-    This simple approach works because the template is created to be exactly 
+    This simple approach works because the template is created to be exactly
     spacing large, so templates do not overlap
     """
-    
+
     # convert fractions into integers
     x_offset = int(x_off*img_shape[0])
     y_offset = int(y_off*img_shape[0])
     spacing = int(sp*img_shape[0])
 
-    # create a padded empty canvas 
+    # create a padded empty canvas
     padding = img_shape[0]//2
     padding_times_2 = padding*2
     padded_shape = tuple(s+padding_times_2 for s in img_shape)
@@ -305,22 +310,22 @@ def simulate_wells_lattice(img_shape, x_off, y_off, sp, nwells=None, template_sh
     if nwells is not None:
         r_wells = range(y_offset+padding,
                         y_offset+padding+nwells*spacing,
-                        spacing) 
+                        spacing)
         c_wells = range(x_offset+padding,
                         x_offset+padding+nwells*spacing,
                         spacing)
     else:
         r_wells = range(y_offset+padding,
                         padding+img_shape[0],
-                        spacing) 
+                        spacing)
         c_wells = range(x_offset+padding,
                         padding+img_shape[1],
                         spacing)
     tmpl_pos_in_padded_canvas = [(r,c) for r in r_wells for c in c_wells]
 
     # make the template for the wells
-    tmpl = make_square_template(n_pxls=spacing, 
-                                rel_width=0.7, 
+    tmpl = make_square_template(n_pxls=spacing,
+                                rel_width=0.7,
                                 blurring=0.1,
                                 dtype_out='float')
     # invert
@@ -330,7 +335,7 @@ def simulate_wells_lattice(img_shape, x_off, y_off, sp, nwells=None, template_sh
     ts = tmpl.shape[0]
     for r,c in tmpl_pos_in_padded_canvas:
         try:
-            padded_canvas[r-ts//2:r-(-ts//2), 
+            padded_canvas[r-ts//2:r-(-ts//2),
                           c-ts//2:c-(-ts//2)] += tmpl
         except Exception as e:
             print(str(e))
@@ -340,7 +345,7 @@ def simulate_wells_lattice(img_shape, x_off, y_off, sp, nwells=None, template_sh
     cutout_canvas = padded_canvas[padding:padding+img_shape[0],
                                   padding:padding+img_shape[1]]
     cutout_canvas = naive_normalise(cutout_canvas)
-    
+
     return cutout_canvas
 
 
@@ -363,14 +368,14 @@ def get_well_color(is_good_well, forCV=False):
 
 
 if __name__ == '__main__':
-    
+
     # test that camera serials return the correct channel
     serials_list = [line[0] for line in CAM2CH_list]
 #    serials_list.append('22594540') # this raise an exception as it does not exist
     for serial in serials_list:
         print('{} -> {}'.format(serial, serial2channel(serial)))
-    # that works as intended! 
-    
+    # that works as intended!
+
     # let's now check that the camera name is parsed correctly I guess
     from pathlib import Path
     src_dir = Path('/Users/lferiani/Desktop/Data_FOVsplitter/evgeny/MaskedVideos/20190808')
@@ -383,7 +388,7 @@ if __name__ == '__main__':
         print(' ')
     # this too works perfectly... but I saw wrong data was written in the masked videos
     # so have to check what went wrong there
-    
+
 
 
 

--- a/tierpsy/helper/params/models_path.py
+++ b/tierpsy/helper/params/models_path.py
@@ -17,7 +17,7 @@ def get_model_filter_worms(p_dict):
                                           'model_isworm_20170407_184845.h5')
     elif which_model == 'pytorch_default':
         model_filter_worms = os.path.join(AUX_FILES_DIR,
-                                          'model_state_isworm_20200501.pth')
+                                          'model_state_isworm_20200615.pth')
     elif which_model == 'custom':
         model_filter_worms = p_dict['path_to_custom_pytorch_model']
         if model_filter_worms == '':

--- a/tierpsy/summary/helper.py
+++ b/tierpsy/summary/helper.py
@@ -5,7 +5,6 @@ Created on Mon Jun  4 10:45:29 2018
 @author: avelinojaver
 """
 from tierpsy.features.tierpsy_features.summary_stats import get_n_worms_estimate
-from tierpsy.analysis.split_fov.helper import was_fov_split
 
 import random
 import math
@@ -17,21 +16,17 @@ fold_args_dflt = {'n_folds' : 5,
                  'time_sample_seconds' : 10*60
                  }
 
-def add_trajectory_info(df_stats, worm_index, timeseries_data, fps):
+def add_trajectory_info(
+        df_stats, worm_index, timeseries_data, fps, is_fov_tosplit=False):
     df_stats['worm_index'] = worm_index
     df_stats['ini_time'] = timeseries_data['timestamp'].min()/fps
     df_stats['tot_time'] = timeseries_data['timestamp'].size/fps
     df_stats['frac_valid_skels'] = (~timeseries_data['length'].isnull()).mean()
 
-    is_fov_tosplit = was_fov_split(timeseries_data)
     if is_fov_tosplit:
-        try:
-            assert len(set(timeseries_data['well_name']) - set(['n/a'])) == 1, \
-        "A single trajectory is spanning more than one well!"
-        except:
-            pdb.set_trace()
         well_name = list(set(timeseries_data['well_name']) - set(['n/a']))[0]
         df_stats['well_name'] = well_name
+
 
     cols = df_stats.columns.tolist()
     if not is_fov_tosplit:

--- a/tierpsy/summary/process_tierpsy.py
+++ b/tierpsy/summary/process_tierpsy.py
@@ -255,7 +255,7 @@ def tierpsy_plate_summary(
 
     # was the fov split in wells? only use the first window to detect that,
     # and to extract the list of well names
-    is_fov_tosplit = was_fov_split(timeseries_data[0])
+    is_fov_tosplit = was_fov_split(fname)
 #    is_fov_tosplit = False
 
     if is_fov_tosplit:
@@ -327,7 +327,7 @@ def tierpsy_trajectories_summary(
         return [pd.DataFrame() for iwin in range(len(time_windows))]
     timeseries_data, blob_features = data_in
 
-    is_fov_tosplit = was_fov_split(timeseries_data[0])
+    is_fov_tosplit = was_fov_split(fname)
     #    is_fov_tosplit = False
     if is_fov_tosplit:
         fovsplitter = FOVMultiWellsSplitter(fname)
@@ -357,7 +357,9 @@ def tierpsy_trajectories_summary(
                     ) # returns empty dataframe when w_ts_data is empty
                 worm_feats['n_skeletons'] = count_skeletons(w_ts_data)
                 worm_feats = pd.DataFrame(worm_feats).T
-                worm_feats = add_trajectory_info(worm_feats, w_ind, w_ts_data, fps)
+                worm_feats = add_trajectory_info(
+                    worm_feats, w_ind, w_ts_data, fps,
+                    is_fov_tosplit=is_fov_tosplit)
 
                 all_summary.append(worm_feats)
             # concatenate all trajectories in given time window into one dataframe


### PR DESCRIPTION
### FOV splitter
Everything outside the wells is now set to 0 in the masked videos. Namely, I find the left edge of the leftmost wells, the right edge of the rightmost well, the top edge of the topmost well, the bottom edge of the bottommost well. Every pixel respectively to the right, left, top, and bottom of these limits, is set to 0. 
Brings down file size. 

### NN filtering of blobs
Including Ziwei's latest pytorch model, this is the new `pytorch_default`.

### Bugfix
In `get_tierpsy_features.py`, the function `save_feats_stats` was incorrectly detecting MWP videos with no worms but dirt outside the wells as non-MWP videos, so producing `features_stats` for said dirt. Now the test of whether a video is of a MWP is a check that `/fov_wells` exists in the `*_featuresN.hdf5` file.