### PR TITLE
compressVideo.py: bugfix

### DIFF
--- a/tierpsy/analysis/compress/compressVideo.py
+++ b/tierpsy/analysis/compress/compressVideo.py
@@ -340,10 +340,6 @@ def compressVideo(video_file, masked_image_file, mask_param,  expected_fps=25,
 
         if is_bgnd_subtraction:
             bg_dataset = createImgGroup(mask_fid, "/bgnd", 1, vid.height, vid.width, is_expandable=False)
-            # because we only save the one background:
-            bg_dataset._v_attrs['save_interval'] = len(vid)
-            # except that if reading with ffmpeg, this could be not accurate.
-            # call it again after reading the whole video!
             bg_dataset[0,:,:] = img_fov
 
         if vid.dtype != np.uint8:
@@ -441,8 +437,8 @@ def compressVideo(video_file, masked_image_file, mask_param,  expected_fps=25,
         # for its number of frames. so set the save_interval again
         if is_bgnd_subtraction:
             # bg_dataset._v_attrs['save_interval'] = len(vid)
-            # so that didn't work. Either I have an off by one,
-            # or if the video is corrupted it's just safer to do:
+            # the above line is not accurate when using ffmpeg,
+            # it's just safer to do:
             bg_dataset._v_attrs['save_interval'] = mask_dataset.shape[0]
 
         # close the video


### PR DESCRIPTION
#### `len(vid)` is not reliable if video is read with ffmpeg.

`len(vid)` was used to add to `bg_dataset` a 'save_interval' attribute which is necessary when using `is_full_bgnd_subtraction==True`.
'save_interval' was being set to the number of frames, when only saving the one background. `len(vid)` is a way to get the number of frames in the original video. But the number of frames is the same as the number of frames in the masked video, so `bg_dataset._v_attrs['save_interval']` is now simply set to be the number of frames in `/mask`, after `/mask` has been created and written to file