### PR TITLE
trajectory filtering can work without blob_features

### DIFF
--- a/tierpsy/summary/filtering.py
+++ b/tierpsy/summary/filtering.py
@@ -47,6 +47,7 @@ def _by_timeseries_values(
 
     return timeseries_data
 
+
 def filter_trajectories(
         timeseries_data, blob_features,
         min_traj_length=None, time_units=None,
@@ -54,20 +55,23 @@ def filter_trajectories(
         timeseries_names=None, min_thresholds=None,
         max_thresholds=None, units=None):
 
-    if (min_traj_length is not None) and (min_traj_length>0):
+    if (min_traj_length is not None) and (min_traj_length > 0):
         timeseries_data = _traj_lenght(timeseries_data, min_traj_length)
-        blob_features =  blob_features.loc[timeseries_data.index, :]
+        if blob_features is not None:
+            blob_features = blob_features.loc[timeseries_data.index, :]
 
     if min_distance_traveled is not None:
         timeseries_data = _distance_traveled(
             timeseries_data, min_distance_traveled)
-        blob_features =  blob_features.loc[timeseries_data.index, :]
+        if blob_features is not None:
+            blob_features = blob_features.loc[timeseries_data.index, :]
 
-    if timeseries_names is not None and len(timeseries_names)>0:
-        for name, min_thres, max_thres in \
-            zip(timeseries_names, min_thresholds, max_thresholds):
-                timeseries_data = _by_timeseries_values(
-                    timeseries_data, name, min_thres, max_thres)
-                blob_features =  blob_features.loc[timeseries_data.index, :]
+    if (timeseries_names is not None) and (len(timeseries_names) > 0):
+        for name, min_thres, max_thres in zip(
+                timeseries_names, min_thresholds, max_thresholds):
+            timeseries_data = _by_timeseries_values(
+                timeseries_data, name, min_thres, max_thres)
+            if blob_features is not None:
+                blob_features = blob_features.loc[timeseries_data.index, :]
 
     return timeseries_data, blob_features

--- a/tierpsy_macosx.yml
+++ b/tierpsy_macosx.yml
@@ -133,7 +133,3 @@ dependencies:
   - zstd=1.4.4
   - pip:
     - imgstore==0.2.9
-    - pyqt5-sip==4.19.18
-    - pyqtchart==5.12
-    - pyqtwebengine==5.12.1
-    - tzlocal==2.1


### PR DESCRIPTION
Minor changes to `filter_trajectories` so it can be used to filter timeseries_data without necessarily having blob_features. Useful when analysing timeseries directly. Should not break normal behaviour.

Also, in the file to create the conda environment, moved pyqt related things to the conda section (from the pip section)