### PR TITLE
silencing futurewarning tensorflow/numpy

### DIFF
--- a/tierpsy/analysis/food_cnt/getFoodContourNN.py
+++ b/tierpsy/analysis/food_cnt/getFoodContourNN.py
@@ -13,7 +13,11 @@ import tables
 import os
 import numpy as np
 import cv2
-from keras.models import load_model
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+    from keras.models import load_model
 
 from skimage.morphology import disk
 

--- a/tierpsy/analysis/ske_init/filterTrajectModel.py
+++ b/tierpsy/analysis/ske_init/filterTrajectModel.py
@@ -3,11 +3,13 @@ from functools import partial
 import numpy as np
 import tables
 import os
+import warnings
 
 try:
-    from keras.models import load_model
+    with warnings.catch_warnings():
+        warnings.simplefilter(action='ignore', category=FutureWarning)
+        from keras.models import load_model
 except ImportError:
-    import warnings
     warnings.warn("`keras` is not found, this will break contour finding ",
                   + "on *_AEX analysis, and may break filter trajectories ",
                   + "unless pytorch is being used")
@@ -15,7 +17,6 @@ except ImportError:
 try:
     import torch
 except ImportError:
-    import warnings
     warnings.warn("`pytorch` not found, this may break filter trajectories ")
 
 from tierpsy.analysis.ske_create.helperIterROI import generateMoviesROI, getROIFixSize


### PR DESCRIPTION
Safely silencing a harmless future warning given by the interplay between tensorflow<1.15 and numpy>1.17