### PR TITLE
Iteritems and numba warning fix

### DIFF
--- a/tierpsy/features/tierpsy_features/helper.py
+++ b/tierpsy/features/tierpsy_features/helper.py
@@ -28,7 +28,7 @@ def load_eigen_projections(n_projections = 7):
     return eigen_worms
 
 
-@numba.jit
+@numba.jit(nopython=True)
 def fillfnan(arr):
     '''
     fill foward nan values (iterate using the last valid nan)
@@ -40,7 +40,7 @@ def fillfnan(arr):
             out[idx] = out[idx - 1]
     return out
 
-@numba.jit
+@numba.jit(nopython=True)
 def fillbnan(arr):
     '''
     fill foward nan values (iterate using the last valid nan)

--- a/tierpsy/features/tierpsy_features/summary_stats.py
+++ b/tierpsy/features/tierpsy_features/summary_stats.py
@@ -164,12 +164,12 @@ def get_df_quantiles(df,
     for q in q_vals:
         q_dat = feat_mean.loc[q]
         q_str = '_{}th'.format(int(round(q*100)))
-        for feat, val in q_dat.iteritems():
+        for feat, val in q_dat.items():
             dat.append((val, feat+q_str))
 
 
     IQR = feat_mean.loc[0.75] - feat_mean.loc[0.25]
-    dat += [(val, feat + '_IQR') for feat, val in IQR.iteritems()]
+    dat += [(val, feat + '_IQR') for feat, val in IQR.items()]
 
     feat_mean_s = pd.Series(*list(zip(*dat)))
     return feat_mean_s


### PR DESCRIPTION
Fixed warnings regarding:
- using soon to be deprecated iteritems() 
- change of default nonpython argument in numba