### PR TITLE
Set default nn_filter_to_use to "none"

### DIFF
--- a/tierpsy/helper/params/docs_tracker_param.py
+++ b/tierpsy/helper/params/docs_tracker_param.py
@@ -315,7 +315,7 @@ dflt_param_list = [
         '''),
 
     ('nn_filter_to_use',
-        'pytorch_default',
+        'none',
         """
         Set to "pytorch_default" or "tensorflow_default" if you want to
         use a pretrained neural network model to filter worms.


### PR DESCRIPTION
Since "pytorch_default" uses a NN model that was trained on Hydra data, it's better not have that as the default option.